### PR TITLE
Exclude the WordPress.Classes.ValidClassName.NotCamelCaps rule

### DIFF
--- a/10up-Third-Party/ruleset.xml
+++ b/10up-Third-Party/ruleset.xml
@@ -37,5 +37,8 @@
 		<!-- Discouraged !== banned functions. -->
 		<exclude name="WordPress.PHP.DiscouragedFunctions.Discouraged" />
 
+		<!-- Don't be too picky about class naming schemes. -->
+		<exclude name="WordPress.Classes.ValidClassName.NotCamelCaps" />
+
 	</rule>
 </ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Added the "10up-Third-Party" standard, a subset of the 10up-Code-Review standard that ignores code issues that _we'd_ never want to put in our code but are pretty common (and relatively harmless) when reviewing third-party code.
 
+## [Unreleased]
+
+* Remove sniffs for "camel cap" class names when reviewing third-party code.
+
 
 ## [0.2.0] - 2016-02-10
 


### PR DESCRIPTION
Found this while reviewing [Admin Post Navigation](https://wordpress.org/plugins/admin-post-navigation/developers/):

> Class name "c2c_AdminPostNavigation" is not in camel caps format

When reviewing third-party code, this is hardly worth throwing an error over.