### PR TITLE
Composer 'scripts' updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Added the "10up-Third-Party" standard, a subset of the 10up-Code-Review standard that ignores code issues that _we'd_ never want to put in our code but are pretty common (and relatively harmless) when reviewing third-party code.
 
+## [Unreleased]
+
+* Update the `composer.json` file to properly install the 10up coding standards upon installation or update.
+
 
 ## [0.2.0] - 2016-02-10
 

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,12 @@
     "bin": [
         "bin/10up-code-review-install"
     ],
-    "post-install-cmd": [
-        "10up-code-review-install"
-    ],
-    "post-update-cmd": [
-        "10up-code-review-install"
-    ]
+    "scripts": {
+        "post-install-cmd": [
+            "bin/10up-code-review-install"
+        ],
+        "post-update-cmd": [
+            "bin/10up-code-review-install"
+        ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
             "email": "steve.grunwell@10up.com"
         }
     ],
+    "support": {
+        "source": "https://github.com/10up/10up-code-review",
+        "issues": "https://github.com/10up/10up-code-review/issues"
+    },
     "bin": [
         "bin/10up-code-review-install"
     ],

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,13 @@
     "license": "MIT",
     "authors": [
         {
+            "name": "10up",
+            "homepage": "https://10up.com"
+        },
+        {
             "name": "Steve Grunwell",
-            "email": "steve.grunwell@10up.com"
+            "email": "steve@stevegrunwell.com",
+            "homepage": "https://stevegrunwell.com"
         }
     ],
     "support": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7368f2146746514ea64aa6d611f8d5a7",
-    "content-hash": "09d60cef65a8bf73f9e1525f588b5f3f",
+    "hash": "0883d6b2e0ab15283bdf4ac0a080ac55",
+    "content-hash": "4b13ce4a524d6bbedb2bc0f2a5e8a3cb",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.5.1",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6731851d6aaf1d0d6c58feff1065227b7fda3ba8"
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6731851d6aaf1d0d6c58feff1065227b7fda3ba8",
-                "reference": "6731851d6aaf1d0d6c58feff1065227b7fda3ba8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
                 "shasum": ""
             },
             "require": {
+                "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
                 "php": ">=5.1.2"
@@ -82,24 +83,24 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-01-19 23:39:10"
+            "time": "2016-11-30 04:02:31"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.9.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "b415094aa5fd24da6eba2295323bcff840902dd3"
+                "reference": "b39490465f6fd7375743a395019cd597e12119c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/b415094aa5fd24da6eba2295323bcff840902dd3",
-                "reference": "b415094aa5fd24da6eba2295323bcff840902dd3",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/b39490465f6fd7375743a395019cd597e12119c9",
+                "reference": "b39490465f6fd7375743a395019cd597e12119c9",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "~2.2"
+                "squizlabs/php_codesniffer": "^2.6"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -118,13 +119,15 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-02-01 16:14:59"
+            "time": "2016-08-29 20:04:47"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "wp-coding-standards/wpcs": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a84f657469f4704e23bde8954c816db1",
+    "hash": "5cecbf2fe4e0eba2623c27632a115d46",
     "content-hash": "4b13ce4a524d6bbedb2bc0f2a5e8a3cb",
     "packages": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0883d6b2e0ab15283bdf4ac0a080ac55",
+    "hash": "a84f657469f4704e23bde8954c816db1",
     "content-hash": "4b13ce4a524d6bbedb2bc0f2a5e8a3cb",
     "packages": [
         {


### PR DESCRIPTION
The `composer.json` file was a bit malformed, as `post-install-cmd` and `post-update-cmd` were at the root, _not_ under a `scripts` property; as a result, the installation commands were not being run as expected.

Other updates in this PR are simply surrounding metadata in the `composer.json` file.