### PR TITLE
Ignore additional formatting errors for 10up-Third-Party

### DIFF
--- a/10up-Third-Party/ruleset.xml
+++ b/10up-Third-Party/ruleset.xml
@@ -44,5 +44,8 @@
 		<!-- It matters not, whether your braces punctuate your line or begin anew, just that they exist. -->
 		<exclude name="WordPress.Classes.ClassOpeningStatement.BraceOnNewLine" />
 
+		<!-- Internationalization isn't hard, but for third-party reviews it's not a deal-breaker. -->
+		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
+
 	</rule>
 </ruleset>

--- a/10up-Third-Party/ruleset.xml
+++ b/10up-Third-Party/ruleset.xml
@@ -47,5 +47,8 @@
 		<!-- Internationalization isn't hard, but for third-party reviews it's not a deal-breaker. -->
 		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
 
+		<!-- ELSEIF and ELSE IF are, for all intents and purposes, the same. -->
+		<exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
+
 	</rule>
 </ruleset>

--- a/10up-Third-Party/ruleset.xml
+++ b/10up-Third-Party/ruleset.xml
@@ -15,6 +15,7 @@
 
 		<!-- Don't be as picky about whitespace. -->
 		<exclude name="Generic.Formatting" />
+		<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound" />
 
 		<!-- People rarely name files correctly. -->
 		<exclude name="WordPress.Files.FileName.UnderscoresNotAllowed" />

--- a/10up-Third-Party/ruleset.xml
+++ b/10up-Third-Party/ruleset.xml
@@ -41,5 +41,8 @@
 		<!-- Don't be too picky about class naming schemes. -->
 		<exclude name="WordPress.Classes.ValidClassName.NotCamelCaps" />
 
+		<!-- It matters not, whether your braces punctuate your line or begin anew, just that they exist. -->
+		<exclude name="WordPress.Classes.ClassOpeningStatement.BraceOnNewLine" />
+
 	</rule>
 </ruleset>

--- a/10up-Third-Party/ruleset.xml
+++ b/10up-Third-Party/ruleset.xml
@@ -15,7 +15,7 @@
 
 		<!-- Don't be as picky about whitespace. -->
 		<exclude name="Generic.Formatting" />
-		<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound" />
+		<exclude name="Squiz.Strings.ConcatenationSpacing" />
 
 		<!-- People rarely name files correctly. -->
 		<exclude name="WordPress.Files.FileName.UnderscoresNotAllowed" />


### PR DESCRIPTION
When running the 10up-Third-Party ruleset today, a few items like whitespace around concatenation, Egyptian-style braces, and `else if` instead of `else` jumped out as being noise in a third-party plugin review.